### PR TITLE
No spaces around concat operator (.)

### DIFF
--- a/Laravel.xml
+++ b/Laravel.xml
@@ -16,6 +16,7 @@
     <option name="ALIGN_PHPDOC_PARAM_NAMES" value="true" />
     <option name="ALIGN_PHPDOC_COMMENTS" value="true" />
     <option name="ALIGN_ASSIGNMENTS" value="true" />
+    <option name="CONCAT_SPACES" value="false" />
     <option name="PHPDOC_BLANK_LINES_AROUND_PARAMETERS" value="true" />
     <option name="PHPDOC_WRAP_LONG_LINES" value="true" />
     <option name="LOWER_CASE_BOOLEAN_CONST" value="true" />


### PR DESCRIPTION
Laravel does not put spaces around concat operator (`.`).
