### PR TITLE
No spaces within group parentheses

### DIFF
--- a/Laravel.xml
+++ b/Laravel.xml
@@ -43,7 +43,6 @@
     <option name="FINALLY_ON_NEW_LINE" value="true" />
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
     <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-    <option name="SPACE_WITHIN_PARENTHESES" value="true" />
     <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
     <option name="SPACE_AFTER_TYPE_CAST" value="true" />
     <option name="CALL_PARAMETERS_WRAP" value="1" />


### PR DESCRIPTION
Hi,

In Laravel code style there is no spaces within group parentheses.

`if(isset( $something ))` should be `if(isset($something))`

`$a = ( $a + $b )` sould be `$a = ($a + $b)`
