### PR TITLE
No consecutive assignments alignment

### DIFF
--- a/Laravel.xml
+++ b/Laravel.xml
@@ -15,7 +15,6 @@
     <option name="ALIGN_KEY_VALUE_PAIRS" value="true" />
     <option name="ALIGN_PHPDOC_PARAM_NAMES" value="true" />
     <option name="ALIGN_PHPDOC_COMMENTS" value="true" />
-    <option name="ALIGN_ASSIGNMENTS" value="true" />
     <option name="CONCAT_SPACES" value="false" />
     <option name="PHPDOC_BLANK_LINES_AROUND_PARAMETERS" value="true" />
     <option name="PHPDOC_WRAP_LONG_LINES" value="true" />


### PR DESCRIPTION
It looks that there is no rules about this, but digging the Laravel code source i see no alignment :

A good example :
https://github.com/laravel/framework/blob/5.3/src/Illuminate/Container/Container.php#L1132:L1135
